### PR TITLE
added more display time to unstake error, and globally set snackbar t…

### DIFF
--- a/src/components/snackbar/custom-snackbar.tsx
+++ b/src/components/snackbar/custom-snackbar.tsx
@@ -8,9 +8,10 @@ interface IProps {
   hide: () => void;
   variant: 'success' | 'warning' | 'error' | 'info';
   testId: string;
+  autoHideDuration?: number;
 }
 
-const CustomSnackbar = ({ message, hide, show, testId, variant }: IProps) => {
+const CustomSnackbar = ({ message, hide, show, testId, variant, autoHideDuration = 2000 }: IProps) => {
   return show ? (
     <Snackbar
       anchorOrigin={{
@@ -18,7 +19,7 @@ const CustomSnackbar = ({ message, hide, show, testId, variant }: IProps) => {
         horizontal: 'left',
       }}
       open={true}
-      autoHideDuration={1200}
+      autoHideDuration={autoHideDuration}
       onClose={hide}
     >
       <CustomSnackBarContent variant={variant} message={message} onClose={hide} data-testid={testId} />

--- a/src/sections/BalancesSection.tsx
+++ b/src/sections/BalancesSection.tsx
@@ -92,6 +92,7 @@ export const BalancesSection = observer(() => {
 
           {/* Cannot unstake now snackbar */}
           <CustomSnackbar
+            autoHideDuration={10000}
             message={alertsTranslations('cannotUnstakeWhenThereAreOrbsReadyToWithdraw')}
             hide={showCannotUnstakeNowSnackbar.setFalse}
             show={showCannotUnstakeNowSnackbar.value}


### PR DESCRIPTION
…o 2 seconds by default if duration not provided